### PR TITLE
Optimize Dockerfile for Accessibility in China and Explicitly Disable Platforms

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,13 +10,15 @@ ENV DOTNET_ROOT=/usr/share/dotnet
 ENV PATH=$PATH:$DOTNET_ROOT:$DOTNET_ROOT/tools
 
 # install GtkSharp
-RUN git clone https://github.com/GtkSharp/GtkSharp.git
+RUN git clone https://bgithub.xyz/GtkSharp/GtkSharp.git
 WORKDIR /mauienv/GtkSharp
 RUN sed -i 's/"8.0.100", "8.0.200"}/"8.0.100", "8.0.200", "8.0.300", "8.0.400"}/g' build.cake  # add missing version bands
 RUN dotnet tool restore
   # ^ this allows debugging using the vscode devcontainer extension 
 RUN dotnet cake --verbosity=diagnostic --BuildTarget=InstallWorkload
-RUN apt update
+RUN sed -i 's#http://deb.debian.org/debian#https://mirrors.aliyun.com/debian#g' /etc/apt/sources.list.d/debian.sources && \
+    sed -i 's#http://deb.debian.org/debian-security#https://mirrors.aliyun.com/debian-security#g' /etc/apt/sources.list.d/debian.sources && \
+    apt-get update
 RUN apt install -y libgtk-3-dev libgtksourceview-4-0
 RUN dotnet new install GtkSharp.Template.CSharp
 WORKDIR /mauienv
@@ -36,17 +38,29 @@ WORKDIR /mauienv
 # finally, if needed, again disable the local display using xhost -
 
 # ___ Read-Only Setup with MAUI Build Already as Part of the Container Image __
-RUN git clone https://github.com/lytico/maui
+RUN git clone https://bgithub.xyz/lytico/maui
 WORKDIR /mauienv/maui
+
+
+# # Overrides Begins++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+RUN rm NuGet.config
 # # make sure to only include Gtk platform using sed
 # # ( see also https://github.com/lytico/maui/blob/6ef7f0c066808ea0d4142812ef4d956245e6a711/.github/workflows/build-gtk.yml#L34-L36 )
 RUN sed -i 's/_IncludeGtk></_IncludeGtk>true</g' Directory.Build.Override.props.in
-RUN sed -i 's/_IncludeWindows>true</_IncludeWindows></g' Directory.Build.Override.props.in
-RUN sed -i 's/_IncludeTizen>true</_IncludeTizen></g' Directory.Build.Override.props.in
-RUN sed -i 's/_IncludeAndroid>true</_IncludeAndroid></g' Directory.Build.Override.props.in
-RUN sed -i 's/_IncludeIos>true</_IncludeIos></g' Directory.Build.Override.props.in
-RUN sed -i 's/_IncludeMacCatalyst>true</_IncludeMacCatalyst></g' Directory.Build.Override.props.in
-RUN sed -i 's/_IncludeMacOS>true</_IncludeMacOS></g' Directory.Build.Override.props.in
+RUN sed -i 's/_IncludeWindows>true</_IncludeWindows>false</g' Directory.Build.Override.props.in
+RUN sed -i 's/_IncludeTizen>true</_IncludeTizen>false</g' Directory.Build.Override.props.in
+RUN sed -i 's/_IncludeAndroid>true</_IncludeAndroid>false</g' Directory.Build.Override.props.in
+RUN sed -i 's/_IncludeIos>true</_IncludeIos>false</g' Directory.Build.Override.props.in
+RUN sed -i 's/_IncludeMacCatalyst>true</_IncludeMacCatalyst>false</g' Directory.Build.Override.props.in
+RUN sed -i 's/_IncludeMacOS>true</_IncludeMacOS>false</g' Directory.Build.Override.props.in
+RUN sed -i 's/_IncludeGtk></_IncludeGtk>true</g' Directory.Build.Override.props
+RUN sed -i 's/_IncludeWindows>true</_IncludeWindows>false</g' Directory.Build.Override.props
+RUN sed -i 's/_IncludeTizen>true</_IncludeTizen>false</g' Directory.Build.Override.props
+RUN sed -i 's/_IncludeAndroid>true</_IncludeAndroid>false</g' Directory.Build.Override.props
+RUN sed -i 's/_IncludeIos>true</_IncludeIos>false</g' Directory.Build.Override.props
+RUN sed -i 's/_IncludeMacCatalyst>true</_IncludeMacCatalyst>false</g' Directory.Build.Override.props
+RUN sed -i 's/_IncludeMacOS>true</_IncludeMacOS>false</g' Directory.Build.Override.props
+# # Overrides Ends------------------------------------------------------------------------------------------------------------------------
 RUN dotnet build Microsoft.Maui.BuildTasks.slnf
 RUN dotnet build Microsoft.Maui.Gtk.slnf
 RUN apt clean
@@ -54,4 +68,3 @@ WORKDIR /mauienv/maui/src/Controls/samples/Controls.Sample
 # on the local terminal type:
 # xhost + & docker run -it --rm -e DISPLAY=$DISPLAY -v /tmp/.X11-unix:/tmp/.X11-unix -t maui-env dotnet run --framework net8.0-gtk & xhost -
 # alternatively, you could omit the xhost commands and attach a VS Code instance to the container and run it there.
-


### PR DESCRIPTION
This PR updates the Dockerfile to address two key improvements:
- Improved Accessibility within China Mainland:  The modifications ensure reliable building and operation of the Docker image for users located within China.
- Explicit Platform Disabling: Specific platform support (Android/Tizen/Mac/iOS) is now explicitly disabled within the Dockerfile to avoid potential compatibility issues.