### PR TITLE
ci: setup ci/cd to push a docker image to gitHub-packages

### DIFF
--- a/.github/workflows/deploy-github-packages.yml
+++ b/.github/workflows/deploy-github-packages.yml
@@ -1,0 +1,59 @@
+name: Create and publish a Docker image
+
+# Configures this workflow to run every time a change is pushed to the branch called `release`.
+on:
+  push:
+  #  branches: ['release']
+  workflow_dispatch:
+
+# Defines two custom environment variables for the workflow. These are used for the Container registry domain, and a name for the Docker image that this workflow builds.
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+# There is a single job in this workflow. It's configured to run on the latest available version of Ubuntu.
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    # Sets the permissions granted to the `GITHUB_TOKEN` for the actions in this job.
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+      #
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      # Uses the `docker/login-action` action to log in to the Container registry registry using the account and password that will publish the packages. Once published, the packages are scoped to the account defined here.
+      - name: Log in to the Container registry
+        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      # This step uses [docker/metadata-action](https://github.com/docker/metadata-action#about) to extract tags and labels that will be applied to the specified image. The `id` "meta" allows the output of this step to be referenced in a subsequent step. The `images` value provides the base name for the tags and labels.
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+      # This step uses the `docker/build-push-action` action to build the image, based on your repository's `Dockerfile`. If the build succeeds, it pushes the image to GitHub Packages.
+      # It uses the `context` parameter to define the build's context as the set of files located in the specified path. For more information, see [Usage](https://github.com/docker/build-push-action#usage) in the README of the `docker/build-push-action` repository.
+      # It uses the `tags` and `labels` parameters to tag and label the image with the output from the "meta" step.
+      - name: Build and push Docker image
+        id: push
+        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+      
+      # This step generates an artifact attestation for the image, which is an unforgeable statement about where and how it was built. It increases supply chain security for people who consume the image. For more information, see [Using artifact attestations to establish provenance for builds](/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds).
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true

--- a/README.md
+++ b/README.md
@@ -3,40 +3,72 @@
 In defailt mode, this is intended to demonstrate issues with the [MAUI](https://github.com/lytico/maui) Gtk platform and not 
 for active development as changes in the container would get lost on a `docker build`. But there is a devcontainer setup to have the maui folder mounted as a docker volume to persist changes to the codebase (see "Optional Setup with Persistent Volume Share on Local Host" section in the Dockerfile).
 
-Note: You need to have [Docker](https://docs.docker.com/engine/install/ubuntu/) installed and set up 
-on your system to use this.
+## How to use
 
-After git-cloning and cd into the repo, build the image:
+### Require
 
-    docker build -t maui-env .
+- [Docker](https://www.docker.com) or [Podman](https://podman.io)
 
-This will build MAUI along with GtkSharp already. Then start the container (which can take a minute) using:
+### Build
 
-    xhost +  # allow container to use the X display of the host
-    # replace the 'dotnet ...' command with 'bash' to have a look inside the container:
-    docker run -it --rm -e DISPLAY=$DISPLAY -v /tmp/.X11-unix:/tmp/.X11-unix -t maui-env dotnet run --framework net8.0-gtk
-    xhost -  # restrict display access again
+You can choose to use github packages or use the source.
+
+#### From GitHub Packages
+
+```sh
+# Pull Docker package
+docker pull ghcr.io/MauiGtk/maui-docker:main
+
+# Build Docker environment
+xhost +  # allow container to use the X display of the host
+# replace the 'dotnet ...' command with 'bash' to have a look inside the container:
+docker run -it --rm -e DISPLAY=$DISPLAY -v /tmp/.X11-unix:/tmp/.X11-unix -t ghcr.io/MauiGtk/maui-docker:main dotnet run --framework net8.0-gtk
+xhost -  # restrict display access again
+```
+
+#### From Sources
+
+```sh
+# git clone
+git clone https://github.com/MauiGtk/maui-docker.git
+cd MauiGtk
+
+# Build Docker package
+docker build -t maui-env .
+
+# Build Docker environment
+xhost +  # allow container to use the X display of the host
+# replace the 'dotnet ...' command with 'bash' to have a look inside the container:
+docker run -it --rm -e DISPLAY=$DISPLAY -v /tmp/.X11-unix:/tmp/.X11-unix -t maui-env dotnet run --framework net8.0-gtk
+xhost -  # restrict display access again
+```
+
+### 
 
 Alternatively, use Visual Studio Code to handle the display and have a deeper look at the MAUI sources:
-* Start VS Code in a new bash outside the container with `code .`,
-* then install VS Codes 'Dev Containers' and 'Docker' extension. After that, 
-* in the 'Containers' item of side panel start the 'maui-env' container and right click / attach it to VS Code, 
-* then click the generated container name at the top. 
-* In the newly opened Code window, wait a few seconds until VS Code is setup in the container.
+1. Start VS Code in a new bash outside the container with `code .`,
+1. then install VS Codes 'Dev Containers' and 'Docker' extension. After that, 
+1. in the 'Containers' item of side panel start the 'maui-env' container and right click / attach it to VS Code, 
+1. then click the generated container name at the top. 
+1. In the newly opened Code window, wait a few seconds until VS Code is setup in the container.
 
 Finally open folder /mauienv/maui/ and enter these commands in VS Codes terminal window:
 
-    cd /mauienv/maui/src/Controls/samples/Controls.Sample
-    dotnet run --framework net8.0-gtk
+```sh
+cd /mauienv/maui/src/Controls/samples/Controls.Sample
+dotnet run --framework net8.0-gtk
+```
 
-... or simply hit Ctrl-Shift-D and launch the sample by pressing the play button.
+... or simply hit <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>D</kbd> and launch the sample by pressing the play button.
 
 ![Controls.Sample](https://raw.githubusercontent.com/Thomas-Mielke-Software/maui-docker/d77cd672b4586fcfbe5a9aea89dff0ea8cfee3f2/pics/ControlsSample.png)
 
 Also have a look at
 
-    cd ../Controls.Sample.Gtk
-    cp ../Controls.Sample/Resources/Images/calculator.png ./dotnet_bot.png  # someone forgot to git add the image
-    dotnet run
+```sh
+cd ../Controls.Sample.Gtk
+cp ../Controls.Sample/Resources/Images/calculator.png ./dotnet_bot.png  # someone forgot to git add the image
+dotnet run
+```
 
 ![Controls.Sample.Gtk](https://raw.githubusercontent.com/Thomas-Mielke-Software/maui-docker/d77cd672b4586fcfbe5a9aea89dff0ea8cfee3f2/pics/ControlsSampleGtk.png)


### PR DESCRIPTION
The Docker image allows users to skip the build process and get started quickly.
